### PR TITLE
mods. in support of LLVM 4.0-8.0

### DIFF
--- a/tools/fact-generator/Makefile
+++ b/tools/fact-generator/Makefile
@@ -11,7 +11,8 @@ include $(LEVEL)/src/common.mk
 CXXFLAGS += -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter    \
             -Wwrite-strings -Wcast-qual -Wmissing-field-initializers      \
             -pedantic -Wno-long-long -ffunction-sections -fdata-sections  \
-            -O3
+            -O1  
+# Linux supports -O3 but macOS for some reason does not
 
 LLVM_CONFIG ?= llvm-config
 
@@ -45,7 +46,7 @@ CPPFLAGS += $(shell $(LLVM_CONFIG) --cppflags)
 LDFLAGS  += $(shell $(LLVM_CONFIG) --ldflags)
 LDLIBS   += $(shell $(LLVM_CONFIG) --libs core irreader)
 LDLIBS   += $(filter-out -lz,$(shell $(LLVM_CONFIG) --system-libs))
-LDLIBS   += -lboost_system -lboost_filesystem -lboost_program_options
+LDLIBS   += -lboost_system -lboost_filesystem -lboost_program_options 
 
 
 #-----------------------------------
@@ -53,7 +54,7 @@ LDLIBS   += -lboost_system -lboost_filesystem -lboost_program_options
 #-----------------------------------
 
 CPPFLAGS += $(addprefix -I ,$(include_dirs))
-CXXFLAGS += -fPIC -g -std=c++11
+CXXFLAGS += -fPIC -g -std=c++11 
 
 $(outdir)/%.o: %.cpp | $(outdir)
 	$(COMPILE.cpp) -o $@ $<
@@ -71,8 +72,8 @@ $(library): $(objects) | $(LIBDIR)
 
 py_objects := $(addprefix $(outdir)/,PyFactGen.o PyFactGen.d) $(library)
 
-$(py_objects): CXXFLAGS += $(shell python-config --includes)
-$(py_objects): LDFLAGS  += $(shell python-config --ldflags)
+$(py_objects): CXXFLAGS += $(shell python-config --includes) 
+$(py_objects): LDFLAGS  += $(shell python-config --ldflags) 
 $(py_objects): LDLIBS   += -lboost_python
 
 #-----------------------------------

--- a/tools/fact-generator/include/DebugInfoProcessorImpl.hpp
+++ b/tools/fact-generator/include/DebugInfoProcessorImpl.hpp
@@ -1,0 +1,223 @@
+#ifndef DEBUG_INFO_PROCESSOR_IMPL_HPP__
+#define DEBUG_INFO_PROCESSOR_IMPL_HPP__
+
+#include <map>
+#include <llvm/IR/DebugInfo.h>
+#include "DebugInfoProcessor.hpp"
+#include "Demangler.hpp"
+#include "FactWriter.hpp"
+#include "ForwardingFactWriter.hpp"
+#include "RefmodeEngine.hpp"
+
+class cclyzer::DebugInfoProcessor::Impl
+    : private Demangler,
+      private ForwardingFactWriter
+{
+  public:
+    Impl(FactWriter& writer, RefmodeEngine& engine)
+        : ForwardingFactWriter(writer), refmEngine(engine) {}
+
+    /* Delegate to debug info finder */
+
+    void
+    processModule(const llvm::Module &module) {
+        debugInfoFinder.processModule(module);
+    }
+
+    void
+    processDeclare(const llvm::Module &module,
+                   const llvm::DbgDeclareInst *inst) {
+        debugInfoFinder.processDeclare(module, inst);
+        record_local_var_assoc(*inst);
+    }
+
+    void
+    processValue(const llvm::Module &module,
+                 const llvm::DbgValueInst *inst) {
+        debugInfoFinder.processValue(module, inst);
+    }
+
+    void reset() { debugInfoFinder.reset(); }
+
+
+    /* Process debug info node and record its attributes */
+    template<typename T, typename writer>
+    struct di_recorder
+    {
+        typedef Impl DIProc;
+
+        static refmode_t
+        record(const T& dinode, DIProc& proc)
+        {
+            const llvm::MDNode& node = llvm::cast<llvm::MDNode>(dinode);
+            auto& nodeIds = proc.nodeIds;
+            auto& eng = proc.refmEngine;
+
+            // Check if node has been processed before
+            auto search = nodeIds.find(&node);
+
+            if (search != nodeIds.end())
+                return search->second;
+
+            // Generate refmode for this node
+            refmode_t nodeId = eng.refmode<llvm::MDNode>(node);
+
+            // Cache the generated refmode and *then* process it
+            // (i.e., record all its attributes, etc), so that it gets
+            // not processed twice in the presence of cyclic
+            // references
+            writer::write(dinode, nodeIds[&node] = nodeId, proc);
+
+            return nodeId;
+        }
+    };
+
+
+    /* Fact-generating methods */
+
+    struct write_di_node {
+        typedef Impl DIProc;
+    };
+
+    struct write_di_file : public write_di_node {
+        static void write(const llvm::DIFile &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_namespace : public write_di_node {
+        static void write(const llvm::DINamespace &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_scope : public write_di_node {
+        static void write(const llvm::DIScope &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_type : public write_di_node {
+        static void write(const llvm::DIType &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_basic_type : public write_di_node {
+        static void write(const llvm::DIBasicType &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_composite_type : public write_di_node {
+        static void write(const llvm::DICompositeType &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_derived_type : public write_di_node {
+        static void write(const llvm::DIDerivedType &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_subroutine_type : public write_di_node {
+        static void write(const llvm::DISubroutineType &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_tpl_param : public write_di_node {
+        static void write(const llvm::DITemplateParameter &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_tpl_type_param : public write_di_node {
+        static void write(const llvm::DITemplateTypeParameter &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_tpl_value_param : public write_di_node {
+        static void write(const llvm::DITemplateValueParameter &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_variable : public write_di_node {
+        static void write(const llvm::DIVariable &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_global_variable : public write_di_node {
+        static void write(const llvm::DIGlobalVariable &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_local_variable : public write_di_node {
+        static void write(const llvm::DILocalVariable &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_subprogram : public write_di_node {
+        static void write(const llvm::DISubprogram &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_lex_block : public write_di_node {
+        static void write(const llvm::DILexicalBlock &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_lex_block_file : public write_di_node {
+        static void write(const llvm::DILexicalBlockFile &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_enumerator : public write_di_node {
+        static void write(const llvm::DIEnumerator &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_subrange : public write_di_node {
+        static void write(const llvm::DISubrange &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_imported_entity : public write_di_node {
+        static void write(const llvm::DIImportedEntity &, const refmode_t &, DIProc &);
+    };
+
+    struct write_di_location : public write_di_node {
+        static void write(const llvm::DILocation &, const refmode_t &, DIProc &);
+    };
+
+
+    /* Type aliases for common recording operations */
+
+    typedef di_recorder<llvm::DIFile, write_di_file> record_di_file;
+    typedef di_recorder<llvm::DINamespace, write_di_namespace> record_di_namespace;
+    typedef di_recorder<llvm::DIScope, write_di_scope> record_di_scope;
+    typedef di_recorder<llvm::DIType, write_di_type> record_di_type;
+    typedef di_recorder<llvm::DITemplateParameter, write_di_tpl_param> record_di_template_param;
+    typedef di_recorder<llvm::DIVariable, write_di_variable> record_di_variable;
+    typedef di_recorder<llvm::DISubprogram, write_di_subprogram> record_di_subprogram;
+    typedef di_recorder<llvm::DIEnumerator, write_di_enumerator> record_di_enumerator;
+    typedef di_recorder<llvm::DISubrange, write_di_subrange> record_di_subrange;
+    typedef di_recorder<llvm::DIImportedEntity, write_di_imported_entity> record_di_imported_entity;
+    typedef di_recorder<llvm::DILocation, write_di_location> record_di_location;
+
+    void
+    generateDebugInfo(const llvm::Module &, const std::string &);
+
+  protected:
+
+    /* Helper method to write common type attributes */
+    void write_di_type_common(const llvm::DIType &, const refmode_t &);
+
+    /* Helper method to write union attributes */
+    template<typename P, typename writer, typename T>
+    void recordUnionAttribute(const refmode_t &, const llvm::TypedDINodeRef<T> & );
+
+    /* Helper method to write bit flags */
+    void recordFlags(const Predicate &, const refmode_t &, unsigned);
+
+    /* Helper method to write constant */
+    refmode_t recordConstant(const llvm::Constant & );
+
+    /* Record association between DI Node and LLVM local variable */
+    void record_local_var_assoc(const llvm::DbgDeclareInst & );
+
+    /* Write all local variable associations */
+    void write_local_var_assocs();
+
+  private:
+    /* Debug Info */
+    llvm::DebugInfoFinder debugInfoFinder;
+
+    /* Mapping from DI Local Variable to LLVM variable */
+    typedef std::multimap<const llvm::DILocalVariable *, refmode_t> LocalVarMap;
+    LocalVarMap localVars;
+
+    /* List of DI Local Variables that correspond to undefined addresses */
+    std::list<const llvm::DILocalVariable *> undefVars;
+
+    /* Refmode Engine */
+    RefmodeEngine &refmEngine;
+
+    /* Cache of processed nodes */
+    std::map<const llvm::MDNode *, refmode_t> nodeIds;
+};
+
+#endif /* DEBUG_INFO_PROCESSOR_IMPL_HPP__ */

--- a/tools/fact-generator/include/FactGenerator.hpp
+++ b/tools/fact-generator/include/FactGenerator.hpp
@@ -25,6 +25,12 @@ namespace cclyzer {
     class FactGenerator;
 }
 
+#if LLVM_VERSION_MAJOR < 5  // AttributeSet ->AttributeList
+typedef llvm::AttributeSet Attributes;
+#else
+typedef llvm::AttributeList Attributes;
+#endif
+
 class cclyzer::FactGenerator
     : private RefmodeEngine,
       private Demangler,
@@ -71,7 +77,7 @@ class cclyzer::FactGenerator
     /* Auxiliary fact writing methods */
 
     template<typename PredGroup>
-    void writeFnAttributes(const refmode_t&, const llvm::AttributeSet);
+    void writeFnAttributes(const refmode_t&, const Attributes);
 
     template<typename PredGroup, class ConstantType>
     void writeConstantWithOperands(const ConstantType&, const refmode_t&);

--- a/tools/fact-generator/include/InstructionVisitor.hpp
+++ b/tools/fact-generator/include/InstructionVisitor.hpp
@@ -156,13 +156,17 @@ class cclyzer::InstructionVisitor
         using namespace llvm;
 
         AtomicOrdering order = instr.getOrdering();
-        SynchronizationScope synchScope = instr.getSynchScope();
-
+        
         refmode_t atomic = gen.refmode<AtomicOrdering>(order);
 
         // default synchScope: crossthread
-        if (synchScope == SingleThread)
+#if LLVM_VERSION_MAJOR < 5  // getSynchScope -> getSyncScopeID
+        if (instr.getSynchScope() == SingleThread) {
+#else
+        if (instr.getSyncScopeID() == SyncScope::SingleThread) {
+#endif
             gen.writeFact(predicates::instruction::flag, iref, "singlethread");
+        }
 
         if (!atomic.empty())
             gen.writeFact(P::ordering, iref, atomic);

--- a/tools/fact-generator/include/predicate.hpp
+++ b/tools/fact-generator/include/predicate.hpp
@@ -16,7 +16,7 @@ namespace cclyzer {
     {
       public:
         Registry() {
-            all().insert(static_cast<const T*>(this));
+            all().insert((const T*)(this));
         }
 
         // Define iterator methods over class instances
@@ -33,7 +33,7 @@ namespace cclyzer {
 
       protected:
         ~Registry() {
-            all().erase(static_cast<const T*>(this));
+            all().erase((const T*)(this));
         }
 
         // Collection of instances

--- a/tools/fact-generator/src/DebugInfoProcessorImpl.cpp
+++ b/tools/fact-generator/src/DebugInfoProcessorImpl.cpp
@@ -33,8 +33,13 @@ DebugInfoProcessor::Impl::generateDebugInfo(
     typedef llvm::DebugInfoFinder::type_iterator di_type_iterator;
     typedef llvm::DebugInfoFinder::scope_iterator di_scope_iterator;
     typedef llvm::DebugInfoFinder::subprogram_iterator di_subprogram_iterator;
-    typedef llvm::DebugInfoFinder::global_variable_iterator di_global_var_iterator;
     typedef llvm::DebugInfoFinder::compile_unit_iterator di_comp_unit_iterator;
+
+#if LLVM_VERSION_MAJOR < 4  // DIGlobalVariable -> DIGlobalVariableExpression
+    typedef llvm::DebugInfoFinder::global_variable_iterator di_global_var_iterator;
+#else
+    typedef llvm::DebugInfoFinder::global_variable_expression_iterator di_global_var_iterator;
+#endif
 
     // Get global variable iterator
     llvm::iterator_range<di_global_var_iterator> allVars =
@@ -44,8 +49,14 @@ DebugInfoProcessor::Impl::generateDebugInfo(
     for (di_global_var_iterator iVar = allVars.begin(), E = allVars.end();
          iVar != E; ++iVar)
     {
+#if LLVM_VERSION_MAJOR < 4  // DIGlobalVariable -> DIGlobalVariableExpression
         const llvm::DIGlobalVariable &divar = **iVar;
         record_di_variable::record(divar, *this);
+#else
+        const llvm::DIGlobalVariableExpression &divarex = **iVar;
+        const llvm::DIGlobalVariable &divar = *divarex.getVariable();
+        record_di_variable::record(divar, *this);
+#endif
     }
 
     // Get subprogram iterator

--- a/tools/fact-generator/src/debuginfo_imports.cpp
+++ b/tools/fact-generator/src/debuginfo_imports.cpp
@@ -1,7 +1,11 @@
-#include <llvm/Support/Dwarf.h>
 #include "DebugInfoProcessorImpl.hpp"
 #include "debuginfo_predicate_groups.hpp"
 
+#if LLVM_VERSION_MAJOR < 5 // Support/Dwarf -> BinaryFormat/Dwarf
+#include <llvm/Support/Dwarf.h>
+#else
+#include <llvm/BinaryFormat/Dwarf.h>
+#endif
 
 using cclyzer::DebugInfoProcessor;
 using cclyzer::refmode_t;

--- a/tools/fact-generator/src/debuginfo_subranges.cpp
+++ b/tools/fact-generator/src/debuginfo_subranges.cpp
@@ -1,3 +1,6 @@
+#if LLVM_VERSION_MAJOR >= 7
+#include <llvm/IR/Constants.h>
+#endif
 #include "DebugInfoProcessorImpl.hpp"
 #include "debuginfo_predicate_groups.hpp"
 
@@ -16,11 +19,18 @@ DebugInfoProcessor::Impl::write_di_subrange::write(
 {
     proc.writeFact(pred::di_subrange::id, nodeId);
 
-    const int64_t count = disubrange.getCount();
+    int64_t count = 0;
+#if LLVM_VERSION_MAJOR < 7
+    count = disubrange.getCount();
+#else
+    auto *CI = disubrange.getCount().dyn_cast<llvm::ConstantInt *>(); 
+    count = CI->getSExtValue();
+#endif
     const int64_t lowerBound = disubrange.getLowerBound();
 
     proc.writeFact(pred::di_subrange::count, nodeId, count);
 
     if (lowerBound)
         proc.writeFact(pred::di_subrange::lower_bound, nodeId, lowerBound);
+
 }

--- a/tools/fact-generator/src/debuginfo_types.cpp
+++ b/tools/fact-generator/src/debuginfo_types.cpp
@@ -77,8 +77,14 @@ DebugInfoProcessor::Impl::write_di_composite_type::write(
       case dwarf::Tag::DW_TAG_enumeration_type:
           proc.writeFact(pred::di_composite_type::enumerations, nodeId); break;
     }
+    
+#if LLVM_VERSION_MAJOR < 4  // const char * -> StringRef
     const char *tagStr = dwarf::TagString(ditype.getTag());
     proc.writeFact(pred::di_composite_type::kind, nodeId, tagStr);
+#else
+    llvm::StringRef tagStr = dwarf::TagString(ditype.getTag());
+    proc.writeFact(pred::di_composite_type::kind, nodeId, tagStr.str());
+#endif
 
     // Record ABI Identifier for this composite type
     const string abiId = ditype.getIdentifier();
@@ -141,8 +147,13 @@ DebugInfoProcessor::Impl::write_di_derived_type::write(
     proc.writeFact(pred::di_derived_type::id, nodeId);
 
     // Record exact kind of derived type
+#if LLVM_VERSION_MAJOR < 4  // const char * -> StringRef
     const char *tagStr = dwarf::TagString(ditype.getTag());
     proc.writeFact(pred::di_derived_type::kind, nodeId, tagStr);
+#else
+    llvm::StringRef tagStr = dwarf::TagString(ditype.getTag());
+    proc.writeFact(pred::di_derived_type::kind, nodeId, tagStr.str());
+#endif
 
     // Record base type
     proc.recordUnionAttribute<pred::di_derived_type::basetype, write_di_type>(

--- a/tools/fact-generator/src/debuginfo_variables.cpp
+++ b/tools/fact-generator/src/debuginfo_variables.cpp
@@ -91,11 +91,13 @@ DebugInfoProcessor::Impl::write_di_global_variable::write(
     }
 
     // Record LLVM global variable association
+#if LLVM_VERSION_MAJOR < 4  // DIGlobalVariable.getVariable eliminated
     if (const llvm::Constant *gv = divar.getVariable())
     {
         std::string name = "@" + gv->getName().str();
         proc.writeFact(pred::di_global_var::variable, nodeId, name);
     }
+#endif
 }
 
 void

--- a/tools/fact-generator/src/functions.cpp
+++ b/tools/fact-generator/src/functions.cpp
@@ -69,9 +69,9 @@ FactGenerator::writeFunction(
 
     // Address not significant
     
-//#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
     // NB: for macOS LLVM-3.9.0svn this does not work, i.e. the test should be
-#if LLVM_VERSION_MAJOR > 3
+    //#if LLVM_VERSION_MAJOR > 3 or equivalent to force else case
     if (func.hasGlobalUnnamedAddr()) {
         writeFact(pred::function::unnamed_addr, funcref);
     }

--- a/tools/fact-generator/src/globals.cpp
+++ b/tools/fact-generator/src/globals.cpp
@@ -113,8 +113,9 @@ FactGenerator::writeGlobalVar(const llvm::GlobalVariable& gv,
 
     // Record section
     if (gv.hasSection()) {
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9
-        writeFact(pred::global_var::section, id, gv.getSection().str());
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
+        llvm::StringRef secStr = gv.getSection();
+        writeFact(pred::global_var::section, id, secStr.str());
 #else
         writeFact(pred::global_var::section, id, gv.getSection());
 #endif

--- a/tools/fact-generator/src/llvm_enums.cpp
+++ b/tools/fact-generator/src/llvm_enums.cpp
@@ -124,13 +124,13 @@ cclyzer::utils::to_string(llvm::AtomicOrdering ordering)
 {
     const char *atomic;
 
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
     using llvm::AtomicOrdering;
 #endif
 
     // Newer LLVM versions use scoped enums
     switch (ordering) {
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
       case AtomicOrdering::NotAtomic:              atomic = "";          break;
       case AtomicOrdering::Unordered:              atomic = "unordered"; break;
       case AtomicOrdering::Monotonic:              atomic = "monotonic"; break;

--- a/tools/fact-generator/src/main.cpp
+++ b/tools/fact-generator/src/main.cpp
@@ -27,7 +27,7 @@ cclyzer::factgen(FileIt firstFile, FileIt endFile,
     using cclyzer::FactGenerator;
     using cclyzer::FactWriter;
 
-#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)
     llvm::LLVMContext context;
 #else
     llvm::LLVMContext &context = llvm::getGlobalContext();

--- a/tools/fact-generator/src/variables.cpp
+++ b/tools/fact-generator/src/variables.cpp
@@ -29,8 +29,10 @@ FactGenerator::writeLocalVariables()
 
         // Record variable name part
         size_t idx = varId.find_last_of("%!");
-        std::string varName = varId.substr(idx);
-        writeFact(pred::variable::name, varId, varName);
+	if (idx != llvm::StringRef::npos) {
+        	std::string varName = varId.substr(idx);
+        	writeFact(pred::variable::name, varId, varName);
+	}
     }
 
     variableTypes.clear();

--- a/tools/fact-generator/src/variables.cpp
+++ b/tools/fact-generator/src/variables.cpp
@@ -29,10 +29,10 @@ FactGenerator::writeLocalVariables()
 
         // Record variable name part
         size_t idx = varId.find_last_of("%!");
-	if (idx != llvm::StringRef::npos) {
+	    if (idx != llvm::StringRef::npos) {
         	std::string varName = varId.substr(idx);
         	writeFact(pred::variable::name, varId, varName);
-	}
+	    }
     }
 
     variableTypes.clear();


### PR DESCRIPTION
Have added a few code bits to allow the fact-generator to be compiled using more current versions of LLVM, which would allow analysis of more software.   Code additions use the #define pattern previously used for LLVM 3.x variants.