### PR TITLE
tools/*/Makefile: Allow to overload -lboost_python

### DIFF
--- a/tools/fact-generator/Makefile
+++ b/tools/fact-generator/Makefile
@@ -15,6 +15,8 @@ CXXFLAGS += -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter    \
 # Linux supports -O3 but macOS for some reason does not
 
 LLVM_CONFIG ?= llvm-config
+LIBBOOST_PYTHON ?= -lboost_python
+
 
 #-----------------------------------
 # Configure paths
@@ -74,7 +76,7 @@ py_objects := $(addprefix $(outdir)/,PyFactGen.o PyFactGen.d) $(library)
 
 $(py_objects): CXXFLAGS += $(shell python-config --includes) 
 $(py_objects): LDFLAGS  += $(shell python-config --ldflags) 
-$(py_objects): LDLIBS   += -lboost_python
+$(py_objects): LDLIBS   += $(LIBBOOST_PYTHON)
 
 #-----------------------------------
 # Phony targets

--- a/tools/json-ast-exporter/Makefile
+++ b/tools/json-ast-exporter/Makefile
@@ -8,6 +8,7 @@ all:
 include $(LEVEL)/src/common.mk
 
 LLVM_CONFIG ?= llvm-config
+LIBBOOST_PYTHON ?= -lboost_python
 
 
 #-----------------------------------
@@ -125,4 +126,4 @@ py_objects += $(library)
 
 $(py_objects): CXXFLAGS += $(shell python-config --includes)
 $(py_objects): LDFLAGS  += $(shell python-config --ldflags)
-$(py_objects): LDLIBS   += -lboost_python
+$(py_objects): LDLIBS   += $(LIBBOOST_PYTHON)


### PR DESCRIPTION
On Fedora 35 libboost_python needs to be linked as -lboost_python310.
Let's allow the default value to be overridden via LIBBOOST_PYTHON,
just like LLVM_CONFIG.

With this patch I was able to build cclyzer-souffle on Fedora 35 using the following instructions:

```
# Install Souffle (instructions below use my Souffle 2.1 package for Fedora)
sudo dnf copr enable cmuellner/souffle
sudo dnf install souffle

# Install other deps (possibly incomplete, YMMV)
sudo dnf install boost-python3 llvm10-devel clang10-devel

# Build cclyzer
LLVM_CONFIG=llvm-config-10-64 LIBBOOST_PYTHON=-lboost_python310 make
```